### PR TITLE
Update number_trivia_local_data_source_test.dart

### DIFF
--- a/test/features/number_trivia/data/datasources/number_trivia_local_data_source_test.dart
+++ b/test/features/number_trivia/data/datasources/number_trivia_local_data_source_test.dart
@@ -49,7 +49,7 @@ void main() {
         // act
         final call = dataSource.getLastNumberTrivia;
         // assert
-        expect(() => call(), throwsA(TypeMatcher<CacheException>()));
+        expect(() => call(), throwsA(isInstanceOf<CacheException>()));
       },
     );
   });


### PR DESCRIPTION
TypeMatcher is deprecated after Flutter v1.12.1.

instanceOf fixes that problem.

The Link: https://api.flutter.dev/flutter/widgets/TypeMatcher-class.html